### PR TITLE
4.x patches

### DIFF
--- a/addons/supabase/Auth/auth.gd
+++ b/addons/supabase/Auth/auth.gd
@@ -273,7 +273,7 @@ func _process_task(task : AuthTask, _fake : bool = false) -> void:
 	else:
 		var httprequest : HTTPRequest = HTTPRequest.new()
 		add_child(httprequest)
-		task.push_request(httprequest)
+		await task.push_request(httprequest)
 
 
 func _on_task_completed(task : AuthTask) -> void:

--- a/addons/supabase/Auth/auth.gd
+++ b/addons/supabase/Auth/auth.gd
@@ -273,7 +273,7 @@ func _process_task(task : AuthTask, _fake : bool = false) -> void:
 	else:
 		var httprequest : HTTPRequest = HTTPRequest.new()
 		add_child(httprequest)
-		await task.push_request(httprequest)
+		task.push_request(httprequest)
 
 
 func _on_task_completed(task : AuthTask) -> void:

--- a/addons/supabase/Auth/auth_error.gd
+++ b/addons/supabase/Auth/auth_error.gd
@@ -5,7 +5,7 @@ class_name SupabaseAuthError
 func _init(dictionary : Dictionary = {}) -> void:
 	_error = dictionary
 	if not _error.is_empty():
-		hint = _error.get("error", "(undefined)")
+		type = _error.get("error", "(undefined)")
 		hint = _error.get("error_description", "(undefined)")
 		if _error.has("code"):
 			code = str(_error.get("code", -1))

--- a/addons/supabase/Auth/auth_task.gd
+++ b/addons/supabase/Auth/auth_task.gd
@@ -33,7 +33,11 @@ func match_code(code: int = Task.NONE) -> int:
 			return HTTPClient.METHOD_GET
 
 func _on_task_completed(result : int, response_code : int, headers : PackedStringArray, body : PackedByteArray, handler: HTTPRequest) -> void:
-	var result_body : Dictionary = JSON.parse_string(body.get_string_from_utf8())
+	var result_body : Dictionary
+	
+	if(!body.is_empty()):
+		result_body = JSON.parse_string(body.get_string_from_utf8())
+	
 	match response_code:
 		200:
 			match _code:
@@ -46,7 +50,6 @@ func _on_task_completed(result : int, response_code : int, headers : PackedStrin
 				Task.LOGOUT, Task.USER:
 					complete()
 		_:
-			if result_body == null : result_body = {}
 			complete(null, {}, SupabaseAuthError.new(result_body))
 	handler.queue_free()
 

--- a/addons/supabase/base_error.gd
+++ b/addons/supabase/base_error.gd
@@ -4,6 +4,7 @@ class_name BaseError
 
 var _error : Dictionary
 var code : String = "empty"
+var type : String = "empty"
 var message : String = "empty"
 var hint : String = "empty"
 var details

--- a/addons/supabase/base_task.gd
+++ b/addons/supabase/base_task.gd
@@ -30,10 +30,10 @@ func _setup(code: int, endpoint: String, headers: PackedStringArray, payload: St
 func match_code(code : int) -> int:
 	return -1
 
-func push_request(httprequest : HTTPRequest) -> Signal:
+func push_request(httprequest : HTTPRequest) -> void:
+	reference()
 	httprequest.request_completed.connect(_on_task_completed.bind(httprequest))
 	httprequest.request(_endpoint, _headers, true, _method, _payload)
-	return httprequest.request_completed
 
 func _on_task_completed(result : int, response_code : int, headers : PackedStringArray, body : PackedByteArray, handler: HTTPRequest) -> void:
 	pass
@@ -42,6 +42,7 @@ func _complete(_data = null, _error : BaseError = null) -> void:
 	data = _data
 	error = _error
 	completed.emit(self)
+	unreference()
 
 func _to_string() -> String:
 	return "%s, %s" % [data, error]

--- a/addons/supabase/base_task.gd
+++ b/addons/supabase/base_task.gd
@@ -30,10 +30,10 @@ func _setup(code: int, endpoint: String, headers: PackedStringArray, payload: St
 func match_code(code : int) -> int:
 	return -1
 
-func push_request(httprequest : HTTPRequest) -> void:
+func push_request(httprequest : HTTPRequest) -> Signal:
 	httprequest.request_completed.connect(_on_task_completed.bind(httprequest))
 	httprequest.request(_endpoint, _headers, true, _method, _payload)
-	await httprequest.request_completed
+	return httprequest.request_completed
 
 func _on_task_completed(result : int, response_code : int, headers : PackedStringArray, body : PackedByteArray, handler: HTTPRequest) -> void:
 	pass

--- a/addons/supabase/base_task.gd
+++ b/addons/supabase/base_task.gd
@@ -33,6 +33,7 @@ func match_code(code : int) -> int:
 func push_request(httprequest : HTTPRequest) -> void:
 	httprequest.request_completed.connect(_on_task_completed.bind(httprequest))
 	httprequest.request(_endpoint, _headers, true, _method, _payload)
+	await httprequest.request_completed
 
 func _on_task_completed(result : int, response_code : int, headers : PackedStringArray, body : PackedByteArray, handler: HTTPRequest) -> void:
 	pass


### PR DESCRIPTION
1. Restored error type.

Reason:
- it is useful
- it is used in demos & examples (it will be simpler to convert them to Godot 4)

```
func _on_auth_error(error : SupabaseAuthError):
	get_tree().call_group("loading_scene", "set_loading")
	match error.type :
		"invalid_grant":
			sign_up(mail ,pwd)
```

2. Fixed responses without body

Reason:
- assigning null to dictionary type causing error
- logout is totally not working (no body in response)

3. Added missing awaits 

Reason:
- sign in is just not working for GDScript style, I'm using todo demo (adjusted for 4.x) like below:

```
# log_screen.gd
func sign_in(email : String, password : String):
	Supabase.auth.sign_in(email, password)
	error_lbl.hide()
```

```
# main.gd
func _ready():
	Supabase.auth.connect("signed_in", _on_signed)
```

And that _on_signed is not executed.
These awaits makes that sign in is working properly and _on_signed is executed.
It fix only GDScript style, JS style don't need that fix.

Looks like example from readme.md not working also without that awaits.

```
func _ready():
	Supabase.auth.signed_in.connect(_on_signed_in)
	Supabase.auth.sign_in(
		"user@supabase.email",
		"userpwd"
	)

func _on_signed_in(user: SupabaseUser) -> void:
	print(user)
```