### PR TITLE
4.x - fixes for verify OTP methods

### DIFF
--- a/addons/supabase/Auth/auth.gd
+++ b/addons/supabase/Auth/auth.gd
@@ -147,7 +147,17 @@ func verify_otp(phone : String, token : String) -> AuthTask:
 	_process_task(auth_task)
 	return auth_task
 
-
+# Verify the OTP token sent to a user as an email
+func verify_otp_email(email : String, token : String, type : String) -> AuthTask:
+	if _auth != "": return _check_auth()
+	var payload : Dictionary = {email = email, token = token, type = type}
+	var auth_task : AuthTask = AuthTask.new()._setup(
+		AuthTask.Task.VERIFYOTP,
+		_config.supabaseUrl + _verify_otp_endpoint, 
+		_header,
+		JSON.stringify(payload))
+	_process_task(auth_task)
+	return auth_task
 
 # Sign in as an anonymous user
 func sign_in_anonymous() -> AuthTask:

--- a/addons/supabase/Auth/auth_task.gd
+++ b/addons/supabase/Auth/auth_task.gd
@@ -25,7 +25,7 @@ var user : SupabaseUser
 
 func match_code(code: int = Task.NONE) -> int:
 	match code:
-		Task.SIGNIN, Task.SIGNUP, Task.LOGOUT, Task.MAGICLINK, Task.RECOVER, Task.REFRESH, Task.INVITE:
+		Task.SIGNIN, Task.SIGNUP, Task.LOGOUT, Task.MAGICLINK, Task.RECOVER, Task.REFRESH, Task.INVITE, Task.VERIFYOTP:
 			return HTTPClient.METHOD_POST
 		Task.UPDATE:
 			return HTTPClient.METHOD_PUT

--- a/addons/supabase/Auth/auth_task.gd
+++ b/addons/supabase/Auth/auth_task.gd
@@ -41,7 +41,7 @@ func _on_task_completed(result : int, response_code : int, headers : PackedStrin
 	match response_code:
 		200:
 			match _code:
-				Task.SIGNUP, Task.SIGNIN, Task.UPDATE, Task.REFRESH:
+				Task.SIGNUP, Task.SIGNIN, Task.UPDATE, Task.REFRESH, Task.VERIFYOTP:
 					complete(SupabaseUser.new(result_body), result_body)
 				Task.MAGICLINK, Task.RECOVER, Task.INVITE:
 					complete()


### PR DESCRIPTION
## What kind of change does this PR introduce?

* fix marking verifyotp as post type request
* add verify_otp_email method for allowing alternative types of email based verification
* add verifyotp to task completion handler for signal dispatch

Bug fix, feature, docs update, ...

Bug fix

## What is the current behavior?

Currently, verifyotp requests will fail as they are not specified to be handled as post requests, so they are called a GET and the API will return a response stating the payload is missing.

I have also added an additional utility function for email based verification, providing an api to specific the verification type 

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
