### PR TITLE
Allow passing data when signing up

### DIFF
--- a/addons/supabase/Auth/auth.gd
+++ b/addons/supabase/Auth/auth.gd
@@ -63,9 +63,9 @@ func _check_auth() -> AuthTask:
 	
 
 # Allow your users to sign up and create a new account.
-func sign_up(email : String, password : String) -> AuthTask:
+func sign_up(email : String, password : String, data: Dictionary = {}) -> AuthTask:
 	if _auth != "": return _check_auth()
-	var payload : Dictionary = {"email":email, "password":password}
+	var payload : Dictionary = {"email":email, "password":password, "data": data}
 	var auth_task : AuthTask = AuthTask.new(
 		AuthTask.Task.SIGNUP,
 		_config.supabaseUrl + _signup_endpoint, 
@@ -77,9 +77,9 @@ func sign_up(email : String, password : String) -> AuthTask:
 
 # Allow your users to sign up and create a new account using phone/password combination.
 # NOTE: the OTP sent to the user must be verified.
-func sign_up_phone(phone : String, password : String) -> AuthTask:
+func sign_up_phone(phone : String, password : String, data: Dictionary = {}) -> AuthTask:
 	if _auth != "": return _check_auth()
-	var payload : Dictionary = {"phone":phone, "password":password}
+	var payload : Dictionary = {"phone":phone, "password":password, "data": data}
 	var auth_task : AuthTask = AuthTask.new(
 		AuthTask.Task.SIGNUPPHONEPASSWORD,
 		_config.supabaseUrl + _signup_endpoint, 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allows passing a `data` dictionary to `sign_up` and `sign_up_phone`. This is stored as metadata for the user.
